### PR TITLE
1.21.5: fix broken settings menu

### DIFF
--- a/src/main/java/com/github/jarada/waygates/util/ItemStackUtil.java
+++ b/src/main/java/com/github/jarada/waygates/util/ItemStackUtil.java
@@ -1,7 +1,11 @@
 package com.github.jarada.waygates.util;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.block.BlockState;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BlockStateMeta;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.jetbrains.annotations.Nullable;
 
@@ -35,14 +39,28 @@ public class ItemStackUtil {
 
             if (o1 == null && o2 == null)
                 continue;
-            
+
             if (o1 == null || o2 == null)
                 return false;
 
-            if (o1.getType() == Material.PLAYER_HEAD && o2.getType() == Material.PLAYER_HEAD) {
+            if (o1.getType() != o2.getType())
+                return false;
+
+            if (o1.getType() == Material.PLAYER_HEAD) {
                 // We verify the inventory on other items, player heads just cause problems
                 // So providing the two items are player heads that will do for us
                 continue;
+            }
+
+            if (o1.getItemMeta() instanceof BlockStateMeta && o2.getItemMeta() instanceof BlockStateMeta) {
+                // Block state meta spontaneously creates "internal" data that causes it to not be equal.
+                // So, we create placeholders for the state part of the meta and compare them.
+                BlockState state = Bukkit.createBlockData(o1.getType()).createBlockState();
+                BlockStateMeta m1 = (BlockStateMeta) o1.getItemMeta();
+                BlockStateMeta m2 = (BlockStateMeta) o2.getItemMeta();
+                m1.setBlockState(state);
+                m2.setBlockState(state);
+                return m1.equals(m2);
             }
 
             if (!(Objects.equals(o1, o2)))


### PR DESCRIPTION
When running on Spigot 1.21.5, the settings menu doesn't work properly: players can remove items from it, and once they've opened the settings menu they won't be able to open any other waygates menus. This PR resolves that.

The issue seems to be the way that the plugin checks to see whether a menu belongs to it, which is by checking if each item in the inventory matches the items it expects to see there. As of 1.21.5, the enchanting table for changing the waygate effect seems to spontaneously create metadata under the key "internal".

Expected metadata:
```
ItemStack{ENCHANTING_TABLE x 1, TILE_ENTITY_META:{meta-type=TILE_ENTITY, display-name={"text":"","extra":[{"text":"Activation Effect","strikethrough":false,"obfuscated":false,"bold":false,"italic":false,"underlined":false,"color":"green"}]}, lore=[{"text":"","extra":[{"text":"Nether","strikethrough":false,"obfuscated":false,"bold":false,"italic":false,"underlined":false,"color":"dark_purple"}]}, {"text":"","extra":[{"text":"Change the visual effect","strikethrough":false,"obfuscated":false,"bold":false,"italic":false,"underlined":false,"color":"white"}]}, {"text":"","extra":[{"text":"of the gate when it","strikethrough":false,"obfuscated":false,"bold":false,"italic":false,"underlined":false,"color":"white"}]}, {"text":"","extra":[{"text":"activates.","strikethrough":false,"obfuscated":false,"bold":false,"italic":false,"underlined":false,"color":"white"}]}], blockMaterial=ENCHANTING_TABLE}}
```

Actual metadata (note the base64 blob near the end):
```
ItemStack{ENCHANTING_TABLE x 1, TILE_ENTITY_META:{meta-type=TILE_ENTITY, display-name={"text":"","extra":[{"text":"Activation Effect","strikethrough":false,"obfuscated":false,"bold":false,"italic":false,"underlined":false,"color":"green"}]}, lore=[{"text":"","extra":[{"text":"Nether","strikethrough":false,"obfuscated":false,"bold":false,"italic":false,"underlined":false,"color":"dark_purple"}]}, {"text":"","extra":[{"text":"Change the visual effect","strikethrough":false,"obfuscated":false,"bold":false,"italic":false,"underlined":false,"color":"white"}]}, {"text":"","extra":[{"text":"of the gate when it","strikethrough":false,"obfuscated":false,"bold":false,"italic":false,"underlined":false,"color":"white"}]}, {"text":"","extra":[{"text":"activates.","strikethrough":false,"obfuscated":false,"bold":false,"italic":false,"underlined":false,"color":"white"}]}], internal=H4sIAAAAAAAA/72SP0/DMBTEL5BUqRGVEEvFlE/AB2CDqmsn9spxXhwrjh05L/3Dp8ehCJZ2qtTpdLLe3U/yCUBg8WG9ateODR8/pRYQyne9d+R4mGPRGUcqyJrfrA8kAKRzZHTgICeT5MiUj094qGRot/0YeksJxOgqCjYeV8iRcjzAbEPcUEjwOHAwbTTBj7pBgrT0tooqfFmPg5JMk5sZltYo/AUA56uzfWP4Quly1UinqYjNxc4Mo7QF1TUpvi3Gs69/EHQMLfYNucLcmEBIxWYXE4fXa4rjYsRqHNh3G9nRBQwdiNx5jKf3E4bxrlhf/RH3SA446fFXvybNcWcqvPyPl5yKO2Dj9JZlaQn4BhO2T9P9AgAA, blockMaterial=ENCHANTING_TABLE}}
```

I've resolved it by adding another exclusion to the function that compares item stacks, where if both items have `BlockStateMeta`, it will create a placeholder `BlockState`, attach it to a copy of each, and then compare the item meta from there. (The "internal" key for BlockStateMeta is the BlockState attached.)